### PR TITLE
The __json__ function should accept a request argument

### DIFF
--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -131,7 +131,7 @@ class BaseMessage(object):
     def msg(self, dict_like_msg):
         self._msg = fedmsg.encoding.dumps(dict_like_msg)
 
-    def __json__(self):
+    def __json__(self, request):
         return dict(
             i=self.i,
             topic=self.topic,

--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -131,7 +131,7 @@ class BaseMessage(object):
     def msg(self, dict_like_msg):
         self._msg = fedmsg.encoding.dumps(dict_like_msg)
 
-    def __json__(self, request):
+    def __json__(self, request=None):
         return dict(
             i=self.i,
             topic=self.topic,


### PR DESCRIPTION
Pyramid allows it.  This is so automatic code like sqlalchemy_traversal can use
it's **json** if needed.
