### PR TITLE
Category column not nullable

### DIFF
--- a/datanommer.models/alembic/versions/5091535d0fb4_category_not_null.py
+++ b/datanommer.models/alembic/versions/5091535d0fb4_category_not_null.py
@@ -1,0 +1,35 @@
+"""category not null
+
+Revision ID: 5091535d0fb4
+Revises: a4f74590bcf
+Create Date: 2013-02-23 23:31:48.450673
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '5091535d0fb4'
+down_revision = 'a4f74590bcf'
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine
+
+
+def upgrade():
+    engine = create_engine("postgresql+psycopg2://localhost:5432/datanommer")
+    conn = engine.connect()
+
+    ctx = MigrationContext.configure(conn)
+    op = Operations(ctx)
+
+    op.alter_column("messages", "category", nullable=False)
+
+
+def downgrade():
+    engine = create_engine("postgresql+psycopg2://localhost:5432/datanommer")
+    conn = engine.connect()
+
+    ctx = MigrationContext.configure(conn)
+    op = Operations(ctx)
+
+    op.alter_column("messages", "category", nullable=True)

--- a/datanommer.models/alembic/versions/a4f74590bcf_determine_category.py
+++ b/datanommer.models/alembic/versions/a4f74590bcf_determine_category.py
@@ -13,26 +13,6 @@ down_revision = 'ae2801c4cd9'
 from alembic import op
 
 
-from sqlalchemy.schema import MetaData
-from sqlalchemy.sql import text
-
-import fedmsg.meta
-import fedmsg.config
-
-from fedmsg.config import _gather_configs_in
-from alembic import context
-config_path = context.config.get_main_option('fedmsg_config_dir')
-filenames = _gather_configs_in(config_path)
-
-config = fedmsg.config.load_config(filenames=filenames)
-fedmsg.meta.make_processors(**config)
-
-filters = []
-for f in fedmsg.meta.processors:
-    filters.append(f.__name__.lower())
-
-metadata = MetaData()
-
 def map_values(row):
     return dict(
         topic=row[0],
@@ -40,6 +20,24 @@ def map_values(row):
     )
 
 def upgrade():
+    from sqlalchemy.sql import text
+
+    import fedmsg.meta
+    import fedmsg.config
+
+    from fedmsg.config import _gather_configs_in
+    from alembic import context
+    config_path = context.config.get_main_option('fedmsg_config_dir')
+    filenames = _gather_configs_in(config_path)
+
+    config = fedmsg.config.load_config(filenames=filenames)
+    fedmsg.meta.make_processors(**config)
+
+    filters = []
+    for f in fedmsg.meta.processors:
+        filters.append(f.__name__.lower())
+
+
     query = "SELECT topic, category FROM messages WHERE category IS NULL"
     bquery = "UPDATE messages SET category = '%s' WHERE topic = '%s'"
 

--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -107,7 +107,7 @@ class BaseMessage(object):
     timestamp = Column(DateTime, nullable=False)
     certificate = Column(UnicodeText)
     signature = Column(UnicodeText)
-    category = Column(UnicodeText)
+    category = Column(UnicodeText, nullable=False)
     _msg = Column(UnicodeText, nullable=False)
 
     @validates('topic')
@@ -125,6 +125,8 @@ class BaseMessage(object):
         for f in filters:
             if f in topic:
                 self.category = f
+            else:
+                self.category = 'Unclassified'
 
         return topic
 


### PR DESCRIPTION
In order to create a new alembic script, the previous script had to be changed. The models give category 'Unclassified' if the category cannot be determined from the topic and
categories from fedmsg. The alembic script alters the nullable property
of the category column.
