### PR TITLE
Feature/user relationships

### DIFF
--- a/datanommer.models/alembic/versions/1d4feffd78fe_add_historic_user_an.py
+++ b/datanommer.models/alembic/versions/1d4feffd78fe_add_historic_user_an.py
@@ -1,0 +1,96 @@
+""" Add historic user and package relationships.
+
+This is pretty much for messages that occur *before* February, 2013.
+
+Revision ID: 1d4feffd78fe
+Revises: 5091535d0fb4
+Create Date: 2013-04-12 13:00:46.452867
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1d4feffd78fe'
+down_revision = '5091535d0fb4'
+
+from alembic import op
+from alembic import context
+
+import random
+
+import sqlalchemy as sa
+from sqlalchemy.sql import text
+
+from fedmsg.meta import (
+    make_processors,
+    msg2usernames,
+    msg2packages,
+)
+import fedmsg.config
+
+import datanommer.models as m
+
+
+def _page(q, chunk=1000):
+    """ Quick utility to page a query, 1000 items at a time.
+    We need this so we don't OOM (out of memory) ourselves loading the world.
+    """
+
+    offset = 0
+    while True:
+        r = False
+        for elem in q.limit(chunk).offset(offset):
+            r = True
+            yield elem
+        offset += chunk
+        if not r:
+            break
+
+
+def upgrade():
+    """ This takes a *really* long time.  Like, hours. """
+
+    config_paths = context.config.get_main_option('fedmsg_config_dir')
+    filenames = fedmsg.config._gather_configs_in(config_paths)
+
+    config = fedmsg.config.load_config(filenames=filenames)
+
+    make_processors(**config)
+
+    engine = op.get_bind().engine
+    m.init(engine=engine)
+    for msg in _page(m.Message.query.order_by(m.Message.timestamp)):
+        print "processing", msg.timestamp, msg.topic
+
+        if msg.users and msg.packages:
+            continue
+
+        changed = False
+
+        if not msg.users:
+            new_usernames = msg2usernames(msg.__json__(), **config)
+            print "Updating users to %r" % new_usernames
+            changed = changed or new_usernames
+            for new_username in new_usernames:
+                new_user = m.User.get_or_create(new_username)
+                msg.users.append(new_user)
+
+        if not msg.packages:
+            new_packagenames = msg2packages(msg.__json__(), **config)
+            print "Updating packages to %r" % new_packagenames
+            changed = changed or new_usernames
+            for new_packagename in new_packagenames:
+                new_package = m.Package.get_or_create(new_packagename)
+                msg.packages.append(new_package)
+
+        if changed and random.random() < 0.01:
+            # Only save if something changed.. and only do it every so often.
+            # We do this so that if we crash, we can kind of pick up where
+            # we left off.  But if we do it on every change: too slow.
+            print " * Saving!"
+            m.session.commit()
+
+    m.session.commit()
+
+
+def downgrade():
+    pass

--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import (
 )
 
 from sqlalchemy.orm import validates
-
+from sqlalchemy.orm.exc import NoResultFound
 
 from sqlalchemy.schema import Table
 from sqlalchemy.ext.declarative import declarative_base
@@ -164,10 +164,28 @@ class User(DeclarativeBase):
     __tablename__ = 'user'
     name = Column(UnicodeText, primary_key=True)
 
+    @classmethod
+    def get_or_create(cls, name):
+        try:
+            return cls.query.filter_by(name=name).one()
+        except NoResultFound:
+            obj = cls(name=name)
+            session.add(obj)
+            return obj
+
 
 class Package(DeclarativeBase):
     __tablename__ = 'package'
     name = Column(UnicodeText, primary_key=True)
+
+    @classmethod
+    def get_or_create(cls, name):
+        try:
+            return cls.query.filter_by(name=name).one()
+        except NoResultFound:
+            obj = cls(name=name)
+            session.add(obj)
+            return obj
 
 
 class Message(DeclarativeBase, BaseMessage):

--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -34,14 +34,19 @@ import logging
 log = logging.getLogger("datanommer")
 
 
-def init(uri=None, alembic_ini=None, create=False):
+def init(uri=None, alembic_ini=None, engine=None, create=False):
     """ Initialize a connection.  Create tables if requested."""
 
-    if uri is None:
+    if uri and engine:
+        raise ValueError("uri and engine cannot both be specified")
+
+    if uri is None and not engine:
         uri = 'sqlite:////tmp/datanommer.db'
         log.warning("No db uri given.  Using %r" % uri)
 
-    engine = create_engine(uri)
+    if uri and not engine:
+        engine = create_engine(uri)
+
     session.configure(bind=engine)
     DeclarativeBase.query = session.query_property()
 


### PR DESCRIPTION
Messages used to just be messages until @housewifehacker contributed code that added User and Package relationships to them.  All messages in our production DB since that code was introduced have those relationships in place.

However, messages from before that time don't have those relationships; queries for messages belonging to a user before February 2013 don't show up (even though the messages are there).

This upgrade script simply steps through all those old messages and adds User/Package relationships where they should be (completing the historic data).
