### PR TITLE
This fixes the test suite that @pypingou found broken.

### DIFF
--- a/datanommer.commands/tests/test_commands.py
+++ b/datanommer.commands/tests/test_commands.py
@@ -38,7 +38,7 @@ class TestCommands(unittest.TestCase):
                 'version': 1
             }
         }
-        self.config.update(fedmsg.config.defaults)
+        self.config.update(fedmsg.config.load_config())
         datanommer.models.init(uri=uri, create=True)
 
     def tearDown(self):


### PR DESCRIPTION
It used to be that 'topic_prefix_re' was in the fedmsg default config,
but it has since been removed in development to make way for non-fedora
installations that will have a non-fedora topic_prefix (like debian).
