### PR TITLE
Fix SQLAlchemy Unicode warning

### DIFF
--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -124,7 +124,7 @@ class BaseMessage(object):
     certificate = Column(UnicodeText)
     signature = Column(UnicodeText)
     category = Column(UnicodeText, nullable=False)
-    source_name = Column(UnicodeText, default="datanommer")
+    source_name = Column(UnicodeText, default=u"datanommer")
     source_version = Column(UnicodeText, default=source_version_default)
     _msg = Column(UnicodeText, nullable=False)
 


### PR DESCRIPTION
This fixes an SAWarning regarding Unicode for the default value of `source_name` in BaseMessage.
