### PR TITLE
Conditionalize the query filters to avoid extra function calls.

### DIFF
--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -269,18 +269,25 @@ class Message(DeclarativeBase, BaseMessage):
         if msg_id:
             query = query.filter(Message.msg_id == msg_id)
 
-        query = query.filter(or_(
-            *[Message.users.any(User.name == u) for u in users]
-        ))
-        query = query.filter(or_(
-            *[Message.packages.any(Package.name == p) for p in packages]
-        ))
-        query = query.filter(or_(
-            *[Message.category == category for category in categories]
-        ))
-        query = query.filter(or_(
-            *[Message.topic == topic for topic in topics]
-        ))
+        if users:
+            query = query.filter(or_(
+                *[Message.users.any(User.name == u) for u in users]
+            ))
+
+        if packages:
+            query = query.filter(or_(
+                *[Message.packages.any(Package.name == p) for p in packages]
+            ))
+
+        if categories:
+            query = query.filter(or_(
+                *[Message.category == category for category in categories]
+            ))
+
+        if topics:
+            query = query.filter(or_(
+                *[Message.topic == topic for topic in topics]
+            ))
 
         total = query.count()
         query = query.order_by(getattr(Message.timestamp, order)())


### PR DESCRIPTION
This makes it so we aren't doing multiple function calls for non-existent arguments.

This seems to add between 1-10 more requests/second in some simple local benchmarks (`ab -c1 -n100`)
