### PR TITLE
Index the message.{msg_id,timestamp}, user.name, and package.name columns.

### DIFF
--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -119,10 +119,10 @@ def source_version_default(context):
 
 class BaseMessage(object):
     id = Column(Integer, primary_key=True)
-    msg_id = Column(UnicodeText, nullable=True, unique=True, default=None)
+    msg_id = Column(UnicodeText, nullable=True, unique=True, default=None, index=True)
     i = Column(Integer, nullable=False)
     topic = Column(UnicodeText, nullable=False)
-    timestamp = Column(DateTime, nullable=False)
+    timestamp = Column(DateTime, nullable=False, index=True)
     certificate = Column(UnicodeText)
     signature = Column(UnicodeText)
     category = Column(UnicodeText, nullable=False)

--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -189,7 +189,8 @@ pack_assoc_table = Table('package_messages', DeclarativeBase.metadata,
 
 class User(DeclarativeBase):
     __tablename__ = 'user'
-    name = Column(UnicodeText, primary_key=True)
+
+    name = Column(UnicodeText, primary_key=True, index=True)
 
     @classmethod
     def get_or_create(cls, name):
@@ -203,7 +204,8 @@ class User(DeclarativeBase):
 
 class Package(DeclarativeBase):
     __tablename__ = 'package'
-    name = Column(UnicodeText, primary_key=True)
+
+    name = Column(UnicodeText, primary_key=True, index=True)
 
     @classmethod
     def get_or_create(cls, name):


### PR DESCRIPTION
I'm not sure if SA will automatically add these to the existing db, or if we'll need to do some alembic magic. :speedboat: 
