### PR TITLE
Feature/grep enhancements

### DIFF
--- a/datanommer.models/setup.py
+++ b/datanommer.models/setup.py
@@ -30,6 +30,7 @@ setup(name='datanommer.models',
       ],
       tests_require=[
           "nose",
+          "fedmsg_meta_fedora_infrastructure",
       ],
       test_suite='nose.collector',
 )

--- a/datanommer.models/tests/test_model.py
+++ b/datanommer.models/tests/test_model.py
@@ -107,3 +107,23 @@ class TestModels(unittest.TestCase):
         datanommer.models.session.flush()
         obj = datanommer.models.Message.query.first()
         eq_(obj.category, 'git')
+
+    def test_grep_all(self):
+        msg = copy.deepcopy(scm_message)
+        datanommer.models.add(msg)
+        datanommer.models.session.flush()
+        t, p, r = datanommer.models.Message.grep()
+        eq_(t, 1)
+        eq_(p, 1)
+        eq_(len(r), 1)
+        eq_(r[0].msg, scm_message['msg'])
+
+    def test_grep_category(self):
+        msg = copy.deepcopy(scm_message)
+        datanommer.models.add(msg)
+        datanommer.models.session.flush()
+        t, p, r = datanommer.models.Message.grep(categories=['git'])
+        eq_(t, 1)
+        eq_(p, 1)
+        eq_(len(r), 1)
+        eq_(r[0].msg, scm_message['msg'])

--- a/datanommer.models/tests/test_model.py
+++ b/datanommer.models/tests/test_model.py
@@ -127,3 +127,12 @@ class TestModels(unittest.TestCase):
         eq_(p, 1)
         eq_(len(r), 1)
         eq_(r[0].msg, scm_message['msg'])
+
+    def test_grep_not_category(self):
+        msg = copy.deepcopy(scm_message)
+        datanommer.models.add(msg)
+        datanommer.models.session.flush()
+        t, p, r = datanommer.models.Message.grep(not_categories=['git'])
+        eq_(t, 0)
+        eq_(p, 0)
+        eq_(len(r), 0)

--- a/datanommer.models/tests/test_model.py
+++ b/datanommer.models/tests/test_model.py
@@ -101,3 +101,9 @@ class TestModels(unittest.TestCase):
         datanommer.models.session.flush()
         eq_(datanommer.models.Message.query.count(), 1)
 
+    def test_categories(self):
+        msg = copy.deepcopy(scm_message)
+        datanommer.models.add(msg)
+        datanommer.models.session.flush()
+        obj = datanommer.models.Message.query.first()
+        eq_(obj.category, 'git')


### PR DESCRIPTION
This is a new feature required for fedora-infra/datagrepper#118

Justification:  now that we have koji messages from the secondary arch instances, we have a ton of spam on the bus.  It would be nice to be able to make datagrepper queries saying "give me everything _but_ the `buildsys.tag` and `buildsys.untag` messages.  This is specifically wanted for the new fedora-packages+datagrepper integration like at https://apps.fedoraproject.org/packages/fedora-release
