### PR TITLE
Cut down on the number of queries.

### DIFF
--- a/datanommer.commands/tests/test_commands.py
+++ b/datanommer.commands/tests/test_commands.py
@@ -63,6 +63,8 @@ class TestCommands(unittest.TestCase):
     def tearDown(self):
         engine = m.session.get_bind()
         m.DeclarativeBase.metadata.drop_all(engine)
+        m._users_seen = set()
+        m._packages_seen = set()
 
     def test_stats(self):
         with patch('datanommer.commands.StatsCommand.get_config') as gc:

--- a/datanommer.consumer/tests/test_consumer.py
+++ b/datanommer.consumer/tests/test_consumer.py
@@ -62,6 +62,8 @@ class TestConsumer(unittest.TestCase):
     def tearDown(self):
         engine = datanommer.models.session.get_bind()
         datanommer.models.DeclarativeBase.metadata.drop_all(engine)
+        datanommer.models._users_seen = set()
+        datanommer.models._packages_seen = set()
 
     def test_duplicate_msg_id(self):
         example_message = dict(

--- a/datanommer.models/tests/test_model.py
+++ b/datanommer.models/tests/test_model.py
@@ -87,6 +87,9 @@ class TestModels(unittest.TestCase):
     def tearDown(self):
         engine = datanommer.models.session.get_bind()
         datanommer.models.DeclarativeBase.metadata.drop_all(engine)
+        # These contain objects bound to the old session, so we have to flush.
+        datanommer.models._user_cache = {}
+        datanommer.models._package_cache = {}
 
     @raises(KeyError)
     def test_add_empty(self):
@@ -105,8 +108,8 @@ class TestModels(unittest.TestCase):
         datanommer.models.add(msg)
 
     def test_add_many_and_count_statements(self):
-
         statements = []
+
         def track(conn, cursor, statement, param, ctx, many):
             statements.append(statement)
 
@@ -117,14 +120,12 @@ class TestModels(unittest.TestCase):
 
         # Add it to the db and check how many queries we made
         datanommer.models.add(msg)
-        pprint.pprint(statements)  # debug
-        eq_(len(statements), 9)
+        eq_(len(statements), 7)
 
         # Add it again and check again
         datanommer.models.add(msg)
-        pprint.pprint(statements)  # debug
-        eq_(len(statements), 16)
-
+        pprint.pprint(statements)
+        eq_(len(statements), 10)
 
     def test_add_missing_cert(self):
         msg = copy.deepcopy(scm_message)

--- a/datanommer.models/tests/test_model.py
+++ b/datanommer.models/tests/test_model.py
@@ -131,6 +131,24 @@ class TestModels(unittest.TestCase):
         del msg['certificate']
         datanommer.models.add(msg)
 
+    def test_add_and_check_for_others(self):
+        # There are no users or packages at the start
+        eq_(datanommer.models.User.query.count(), 0)
+        eq_(datanommer.models.Package.query.count(), 0)
+
+        # Then add a message
+        msg = copy.deepcopy(scm_message)
+        datanommer.models.add(msg)
+
+        # There should now be one of each
+        eq_(datanommer.models.User.query.count(), 1)
+        eq_(datanommer.models.Package.query.count(), 1)
+
+        # If we add it again, there should be no duplicates
+        datanommer.models.add(msg)
+        eq_(datanommer.models.User.query.count(), 1)
+        eq_(datanommer.models.Package.query.count(), 1)
+
     def test_add_nothing(self):
         eq_(datanommer.models.Message.query.count(), 0)
 

--- a/datanommer.models/tests/test_model.py
+++ b/datanommer.models/tests/test_model.py
@@ -88,8 +88,8 @@ class TestModels(unittest.TestCase):
         engine = datanommer.models.session.get_bind()
         datanommer.models.DeclarativeBase.metadata.drop_all(engine)
         # These contain objects bound to the old session, so we have to flush.
-        datanommer.models._user_cache = {}
-        datanommer.models._package_cache = {}
+        datanommer.models._users_seen = set()
+        datanommer.models._packages_seen = set()
 
     @raises(KeyError)
     def test_add_empty(self):


### PR DESCRIPTION
For the first insert, there are 7 sql statements.  They are:
- check if the user exists
- create the user
- check if the package exists
- create the package
- create the message
- associate the message with the user
- associate the message with the package

Then, for the second insert, there are 3 more sql statements:
- create the message
- associate the message with the user
- associate the message with the package

Should hopefully be an improvement.
