### PR TITLE
Fix IntegrityError bug.

### DIFF
--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -127,13 +127,13 @@ def add(message):
             User.get_or_create(username)
             # Then just mark an in memory cache noting that we've seen them.
             _users_seen.add(username)
-            session.commit()
 
     for package in packages:
         if package not in _packages_seen:
             Package.get_or_create(package)
             _packages_seen.add(package)
-            session.commit()
+
+    session.flush()
 
     # These two blocks would normally be a simple "obj.users.append(user)" kind
     # of statement, but here we drop down out of sqlalchemy's ORM and into the

--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -127,11 +127,13 @@ def add(message):
             User.get_or_create(username)
             # Then just mark an in memory cache noting that we've seen them.
             _users_seen.add(username)
+            session.commit()
 
     for package in packages:
         if package not in _packages_seen:
             Package.get_or_create(package)
             _packages_seen.add(package)
+            session.commit()
 
     # These two blocks would normally be a simple "obj.users.append(user)" kind
     # of statement, but here we drop down out of sqlalchemy's ORM and into the

--- a/datanommer.models/tests/test_model.py
+++ b/datanommer.models/tests/test_model.py
@@ -146,8 +146,16 @@ class TestModels(unittest.TestCase):
         eq_(datanommer.models.Package.query.count(), 1)
 
         # If we add it again, there should be no duplicates
+        msg['msg']['msg_id'] = 'foobar2'
         datanommer.models.add(msg)
         eq_(datanommer.models.User.query.count(), 1)
+        eq_(datanommer.models.Package.query.count(), 1)
+
+        msg = copy.deepcopy(scm_message)
+        msg['msg']['commit']['username'] = 'ralph'
+        msg['msg']['msg_id'] = 'foobar3'
+        datanommer.models.add(msg)
+        eq_(datanommer.models.User.query.count(), 2)
         eq_(datanommer.models.Package.query.count(), 1)
 
     def test_add_nothing(self):

--- a/datanommer.models/tests/test_model.py
+++ b/datanommer.models/tests/test_model.py
@@ -156,12 +156,12 @@ class TestModels(unittest.TestCase):
 
         # Add it to the db and check how many queries we made
         datanommer.models.add(msg)
-        eq_(len(statements), 7)
+        eq_(len(statements), 8)
 
         # Add it again and check again
         datanommer.models.add(msg)
         pprint.pprint(statements)
-        eq_(len(statements), 10)
+        eq_(len(statements), 11)
 
     def test_add_missing_cert(self):
         msg = copy.deepcopy(scm_message)

--- a/datanommer.models/tests/test_model.py
+++ b/datanommer.models/tests/test_model.py
@@ -156,12 +156,12 @@ class TestModels(unittest.TestCase):
 
         # Add it to the db and check how many queries we made
         datanommer.models.add(msg)
-        eq_(len(statements), 8)
+        eq_(len(statements), 7)
 
         # Add it again and check again
         datanommer.models.add(msg)
         pprint.pprint(statements)
-        eq_(len(statements), 11)
+        eq_(len(statements), 10)
 
     def test_add_missing_cert(self):
         msg = copy.deepcopy(scm_message)


### PR DESCRIPTION
This bug has been lurking since last week and was introduced in #70.
The effect is that messages get inserted just fine, but their relationships
never make it into place in some cases.  With postgres, we have to force the
insert of the User and/or Package first before we can try to insert in the
association table.  When we used the ORM by itself, this was handled for us.
Now that we drop down a layer to the sql abstraction, we have to make sure our
`.commit()` ordering is right.
