### PR TITLE
Port datanommer.models to Python 3

### DIFF
--- a/datanommer.models/alembic/versions/198447250956_one_model.py
+++ b/datanommer.models/alembic/versions/198447250956_one_model.py
@@ -77,7 +77,7 @@ def upgrade():
         query = base_query % tname
 
         results = engine.execute(text(query))
-        data = map(map_values, results.fetchall())
+        data = list(map(map_values, results.fetchall()))
 
         if data:
             op.bulk_insert(messages_table, data)
@@ -130,7 +130,7 @@ def downgrade():
         tname = '%s_messages' % table
         results = engine.execute(text(base_query.format(table)))
 
-        data = map(map_values, results.fetchall())
+        data = list(map(map_values, results.fetchall()))
 
         if data:
             op.bulk_insert(db_tables[tname], data)

--- a/datanommer.models/alembic/versions/1d4feffd78fe_add_historic_user_an.py
+++ b/datanommer.models/alembic/versions/1d4feffd78fe_add_historic_user_an.py
@@ -74,7 +74,7 @@ def upgrade():
     engine = op.get_bind().engine
     m.init(engine=engine)
     for msg in _page(m.Message.query.order_by(m.Message.timestamp)):
-        print "processing", msg.timestamp, msg.topic
+        print("processing %s %s" % (msg.timestamp, msg.topic))
 
         if msg.users and msg.packages:
             continue
@@ -83,7 +83,7 @@ def upgrade():
 
         if not msg.users:
             new_usernames = msg2usernames(msg.__json__(), **config)
-            print "Updating users to %r" % new_usernames
+            print("Updating users to %r" % new_usernames)
             changed = changed or new_usernames
             for new_username in new_usernames:
                 new_user = m.User.get_or_create(new_username)
@@ -91,7 +91,7 @@ def upgrade():
 
         if not msg.packages:
             new_packagenames = msg2packages(msg.__json__(), **config)
-            print "Updating packages to %r" % new_packagenames
+            print("Updating packages to %r" % new_packagenames)
             changed = changed or new_usernames
             for new_packagename in new_packagenames:
                 new_package = m.Package.get_or_create(new_packagename)
@@ -101,7 +101,7 @@ def upgrade():
             # Only save if something changed.. and only do it every so often.
             # We do this so that if we crash, we can kind of pick up where
             # we left off.  But if we do it on every change: too slow.
-            print " * Saving!"
+            print(" * Saving!")
             m.session.commit()
 
     m.session.commit()

--- a/datanommer.models/setup.py
+++ b/datanommer.models/setup.py
@@ -47,5 +47,9 @@ setup(name='datanommer.models',
           "nose",
           "fedmsg_meta_fedora_infrastructure",
       ],
+      classifiers=[
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 3',
+      ],
       test_suite='nose.collector',
 )


### PR DESCRIPTION
Hi!
I found that datanommer.models is mostly compatible with Python 3 – at least all the tests pass. Here are a few extra modifications for migration files to make the package forward-compatible.
