### PR TITLE
allow overriding the default "*" subscription

### DIFF
--- a/datanommer.consumer/datanommer/consumer/__init__.py
+++ b/datanommer.consumer/datanommer/consumer/__init__.py
@@ -34,6 +34,12 @@ class Nommer(fedmsg.consumers.FedmsgConsumer):
     config_key = 'datanommer.enabled'
 
     def __init__(self, hub):
+        # The superclass __init__() subscribes the hub to the topic specified
+        # by the consumer. If we have a topic we want use instead of "*", it
+        # needs to be set before calling the superclass.
+        if 'datanommer.topic' in hub.config:
+            self.topic = hub.config['datanommer.topic']
+
         super(Nommer, self).__init__(hub)
 
         # If fedmsg doesn't think we should be enabled, then we should quit


### PR DESCRIPTION
There are cases where a client may not want to consume all messages
(or may not have the permissions to do so). This change allows the
default subscription to the "*" topic to be overridden via the
config.