### PR TITLE
Store and return fields needed for crypto validation.

### DIFF
--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -112,6 +112,8 @@ def add(message):
         msg_id=msg_id or unicode(uuid.uuid4()),
         topic=message['topic'],
         timestamp=timestamp,
+        username=message.get('username', None),
+        crypto=message.get('crypto', None),
         certificate=message.get('certificate', None),
         signature=message.get('signature', None),
     )
@@ -184,6 +186,8 @@ class BaseMessage(object):
     certificate = Column(UnicodeText)
     signature = Column(UnicodeText)
     category = Column(UnicodeText, nullable=False)
+    username = Column(UnicodeText)
+    crypto = Column(UnicodeText)
     source_name = Column(UnicodeText, default=u"datanommer")
     source_version = Column(UnicodeText, default=source_version_default)
     _msg = Column(UnicodeText, nullable=False)
@@ -217,6 +221,8 @@ class BaseMessage(object):
             timestamp=self.timestamp,
             certificate=self.certificate,
             signature=self.signature,
+            username=self.username,
+            crypto=self.crypto,
             msg=self.msg,
             source_name=self.source_name,
             source_version=self.source_version,

--- a/datanommer.models/tests/test_model.py
+++ b/datanommer.models/tests/test_model.py
@@ -67,6 +67,7 @@ scm_message = {
     },
     "signature": "blah",
     "certificate": "blah",
+    "username": "mjw",
 }
 
 
@@ -102,7 +103,8 @@ github_message = {
     "source_name": "datanommer",
     "source_version": "0.6.4",
     "timestamp": 1403127164.0,
-    "topic": "org.fedoraproject.prod.github.webhook"
+    "topic": "org.fedoraproject.prod.github.webhook",
+    "crypto": "x509",
 }
 
 
@@ -184,6 +186,20 @@ class TestModels(unittest.TestCase):
         # 10 seconds between adding the message and checking
         # the timestamp should be more than enough.
         self.assertTrue(timediff < datetime.timedelta(seconds=10))
+
+    def test_extract_base_username(self):
+        msg = copy.deepcopy(scm_message)
+        datanommer.models.add(msg)
+        dbmsg = datanommer.models.Message.query.first()
+        self.assertEquals(dbmsg.__json__()['username'], msg['username'])
+        self.assertEquals(dbmsg.__json__()['crypto'], None)
+
+    def test_extract_crypto_type(self):
+        msg = copy.deepcopy(github_message)
+        datanommer.models.add(msg)
+        dbmsg = datanommer.models.Message.query.first()
+        self.assertEquals(dbmsg.__json__()['username'], None)
+        self.assertEquals(dbmsg.__json__()['crypto'], 'x509')
 
     def test_add_many_and_count_statements(self):
         statements = []


### PR DESCRIPTION
Today, when fedmsg-hub starts up, it tries to read in its backlog of
messages from datagrepper in case it missed anything.  It successfully
gets the list, but then every single one of the messages fails
validation.

There's a gist here that demonstrates what needs to happen to make this
work:  https://gist.github.com/ralphbean/b532ad3bc4a8333fa03d4e4e48451885

There's one change here, in datanommer, and a second change needed in
fedmsg itself.