### PR TITLE
make auto-generated msg_ids consistent with fedmsg

### DIFF
--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -107,9 +107,11 @@ def add(message):
         pass
 
     msg_id = message.get('msg_id', None)
+    if not msg_id:
+        msg_id = unicode(timestamp.year) + u'-' + unicode(uuid.uuid4())
     obj = Message(
         i=message.get('i', 0),
-        msg_id=msg_id or unicode(uuid.uuid4()),
+        msg_id=msg_id,
         topic=message['topic'],
         timestamp=timestamp,
         username=message.get('username', None),

--- a/datanommer.models/tests/test_model.py
+++ b/datanommer.models/tests/test_model.py
@@ -187,6 +187,21 @@ class TestModels(unittest.TestCase):
         # the timestamp should be more than enough.
         self.assertTrue(timediff < datetime.timedelta(seconds=10))
 
+    def test_add_missing_msg_id_with_timestamp(self):
+        msg = copy.deepcopy(scm_message)
+        datanommer.models.add(msg)
+        dbmsg = datanommer.models.Message.query.first()
+        year = datetime.datetime.now().year
+        self.assertTrue(dbmsg.msg_id.startswith('2012-'))
+
+    def test_add_missing_msg_id_no_timestamp(self):
+        msg = copy.deepcopy(scm_message)
+        del msg['timestamp']
+        datanommer.models.add(msg)
+        dbmsg = datanommer.models.Message.query.first()
+        year = datetime.datetime.now().year
+        self.assertTrue(dbmsg.msg_id.startswith(unicode(year) + u'-'))
+
     def test_extract_base_username(self):
         msg = copy.deepcopy(scm_message)
         datanommer.models.add(msg)


### PR DESCRIPTION
fedmsg generates msg_ids that are prefixed with the current year.
Follow the same convention when auto-generating msg_ids for messages
with no msg_id provided. Use the year from the message timestamp.