### PR TITLE
store headers, too!

### DIFF
--- a/datanommer.consumer/datanommer/consumer/__init__.py
+++ b/datanommer.consumer/datanommer/consumer/__init__.py
@@ -54,7 +54,7 @@ class Nommer(fedmsg.consumers.FedmsgConsumer):
     def consume(self, message):
         log.debug("Nomming %r" % message)
         try:
-            datanommer.models.add(message['body'])
+            datanommer.models.add(message)
         except Exception:
             datanommer.models.session.rollback()
             raise

--- a/datanommer.models/alembic/env.py
+++ b/datanommer.models/alembic/env.py
@@ -30,7 +30,8 @@ fileConfig(config.config_file_name)
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-target_metadata = None
+from datanommer.models import DeclarativeBase
+target_metadata = DeclarativeBase.metadata
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:

--- a/datanommer.models/alembic/versions/a356c9a10463_store_headers.py
+++ b/datanommer.models/alembic/versions/a356c9a10463_store_headers.py
@@ -1,0 +1,33 @@
+"""store headers
+
+Revision ID: a356c9a10463
+Revises: 1b786d5fc66
+Create Date: 2017-05-09 16:03:29.944652
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'a356c9a10463'
+down_revision = '1b786d5fc66'
+
+import time
+import logging
+
+from alembic import op
+import sqlalchemy as sa
+
+log = logging.getLogger('alembic.migration')
+
+def upgrade():
+    start = time.time()
+    try:
+        op.add_column('messages', sa.Column('_headers', sa.UnicodeText(), nullable=True))
+    finally:
+        log.info("Finished in %0.2fs", time.time() - start)
+
+def downgrade():
+    start = time.time()
+    try:
+        op.drop_column('messages', '_headers')
+    finally:
+        log.info("Finished in %0.2fs", time.time() - start)

--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -94,9 +94,11 @@ def init(uri=None, alembic_ini=None, engine=None, create=False):
         DeclarativeBase.metadata.create_all(engine)
 
 
-def add(message):
-    """ Take a dict-like fedmsg message and store it in the table.
+def add(envelope):
+    """ Take a dict-like fedmsg envelope and store the headers and message
+        in the table.
     """
+    message = envelope['body']
     timestamp = message.get('timestamp', None)
     try:
         if timestamp:
@@ -121,6 +123,7 @@ def add(message):
     )
 
     obj.msg = message['msg']
+    obj.headers = envelope.get('headers')
 
     session.add(obj)
 
@@ -193,6 +196,7 @@ class BaseMessage(object):
     source_name = Column(UnicodeText, default=u"datanommer")
     source_version = Column(UnicodeText, default=source_version_default)
     _msg = Column(UnicodeText, nullable=False)
+    _headers = Column(UnicodeText)
 
     @validates('topic')
     def get_category(self, key, topic):
@@ -211,6 +215,21 @@ class BaseMessage(object):
     def msg(self, dict_like_msg):
         self._msg = fedmsg.encoding.dumps(dict_like_msg)
 
+    @hybrid_property
+    def headers(self):
+        hdrs = self._headers
+        if hdrs:
+            return fedmsg.encoding.loads(hdrs)
+        else:
+            return {}
+
+    @headers.setter
+    def headers(self, headers):
+        if headers:
+            self._headers = fedmsg.encoding.dumps(headers)
+        else:
+            self._headers = None
+
     @classmethod
     def from_msg_id(cls, msg_id):
         return cls.query.filter(cls.msg_id == msg_id).first()
@@ -226,6 +245,7 @@ class BaseMessage(object):
             username=self.username,
             crypto=self.crypto,
             msg=self.msg,
+            headers=self.headers,
             source_name=self.source_name,
             source_version=self.source_version,
         )

--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -108,7 +108,10 @@ def add(envelope):
     except Exception:
         pass
 
+    headers = envelope.get('headers', None)
     msg_id = message.get('msg_id', None)
+    if not msg_id and headers:
+        msg_id = headers.get('message-id', None)
     if not msg_id:
         msg_id = unicode(timestamp.year) + u'-' + unicode(uuid.uuid4())
     obj = Message(
@@ -123,7 +126,7 @@ def add(envelope):
     )
 
     obj.msg = message['msg']
-    obj.headers = envelope.get('headers')
+    obj.headers = headers
 
     session.add(obj)
 

--- a/datanommer.models/tests/test_model.py
+++ b/datanommer.models/tests/test_model.py
@@ -348,3 +348,10 @@ class TestModels(unittest.TestCase):
         datanommer.models.add(msg)
         dbmsg = datanommer.models.Message.query.first()
         self.assertEquals(dbmsg.headers, msg['headers'])
+
+    def test_add_headers_message_id(self):
+        msg = copy.deepcopy(scm_message)
+        msg['headers'] = {'message-id': 'abc123'}
+        datanommer.models.add(msg)
+        dbmsg = datanommer.models.Message.query.first()
+        self.assertEquals(dbmsg.msg_id, 'abc123')

--- a/datanommer.models/tests/test_model.py
+++ b/datanommer.models/tests/test_model.py
@@ -35,6 +35,7 @@ USE_SQLITE = True  # False
 filename = ":memory:"
 
 scm_message = {
+"body": {
     "i": 1,
     "timestamp": 1344350850.8867381,
     "topic": "org.fedoraproject.prod.git.receive.valgrind.master",
@@ -69,9 +70,11 @@ scm_message = {
     "certificate": "blah",
     "username": "mjw",
 }
+}
 
 
 github_message = {
+"body": {
     "i": 2,
     "msg": {
         "compare": "https://github.com/ralphbean/apps.fp.o",
@@ -105,6 +108,7 @@ github_message = {
     "timestamp": 1403127164.0,
     "topic": "org.fedoraproject.prod.github.webhook",
     "crypto": "x509",
+}
 }
 
 
@@ -172,14 +176,14 @@ class TestModels(unittest.TestCase):
 
     def test_add_missing_i(self):
         msg = copy.deepcopy(scm_message)
-        del msg['i']
+        del msg['body']['i']
         datanommer.models.add(msg)
         dbmsg = datanommer.models.Message.query.first()
         self.assertEqual(dbmsg.i, 0)
 
     def test_add_missing_timestamp(self):
         msg = copy.deepcopy(scm_message)
-        del msg['timestamp']
+        del msg['body']['timestamp']
         datanommer.models.add(msg)
         dbmsg = datanommer.models.Message.query.first()
         timediff = datetime.datetime.now() - dbmsg.timestamp
@@ -196,7 +200,7 @@ class TestModels(unittest.TestCase):
 
     def test_add_missing_msg_id_no_timestamp(self):
         msg = copy.deepcopy(scm_message)
-        del msg['timestamp']
+        del msg['body']['timestamp']
         datanommer.models.add(msg)
         dbmsg = datanommer.models.Message.query.first()
         year = datetime.datetime.now().year
@@ -206,7 +210,7 @@ class TestModels(unittest.TestCase):
         msg = copy.deepcopy(scm_message)
         datanommer.models.add(msg)
         dbmsg = datanommer.models.Message.query.first()
-        self.assertEquals(dbmsg.__json__()['username'], msg['username'])
+        self.assertEquals(dbmsg.__json__()['username'], msg['body']['username'])
         self.assertEquals(dbmsg.__json__()['crypto'], None)
 
     def test_extract_crypto_type(self):
@@ -238,7 +242,7 @@ class TestModels(unittest.TestCase):
 
     def test_add_missing_cert(self):
         msg = copy.deepcopy(scm_message)
-        del msg['certificate']
+        del msg['body']['certificate']
         datanommer.models.add(msg)
 
     def test_add_and_check_for_others(self):
@@ -255,14 +259,14 @@ class TestModels(unittest.TestCase):
         eq_(datanommer.models.Package.query.count(), 1)
 
         # If we add it again, there should be no duplicates
-        msg['msg']['msg_id'] = 'foobar2'
+        msg['body']['msg']['msg_id'] = 'foobar2'
         datanommer.models.add(msg)
         eq_(datanommer.models.User.query.count(), 1)
         eq_(datanommer.models.Package.query.count(), 1)
 
         msg = copy.deepcopy(scm_message)
-        msg['msg']['commit']['username'] = 'ralph'
-        msg['msg']['msg_id'] = 'foobar3'
+        msg['body']['msg']['commit']['username'] = 'ralph'
+        msg['body']['msg']['msg_id'] = 'foobar3'
         datanommer.models.add(msg)
         eq_(datanommer.models.User.query.count(), 2)
         eq_(datanommer.models.Package.query.count(), 1)
@@ -291,7 +295,7 @@ class TestModels(unittest.TestCase):
         eq_(t, 1)
         eq_(p, 1)
         eq_(len(r), 1)
-        eq_(r[0].msg, scm_message['msg'])
+        eq_(r[0].msg, scm_message['body']['msg'])
 
     def test_grep_category(self):
         msg = copy.deepcopy(scm_message)
@@ -301,7 +305,7 @@ class TestModels(unittest.TestCase):
         eq_(t, 1)
         eq_(p, 1)
         eq_(len(r), 1)
-        eq_(r[0].msg, scm_message['msg'])
+        eq_(r[0].msg, scm_message['body']['msg'])
 
     def test_grep_not_category(self):
         msg = copy.deepcopy(scm_message)
@@ -331,3 +335,16 @@ class TestModels(unittest.TestCase):
 
         t = queried.timestamp
         eq_(t, datetime.datetime(2014, 6, 18, 21, 32, 44))
+
+    def test_add_no_headers(self):
+        msg = copy.deepcopy(scm_message)
+        datanommer.models.add(msg)
+        dbmsg = datanommer.models.Message.query.first()
+        self.assertEquals(dbmsg.headers, {})
+
+    def test_add_headers(self):
+        msg = copy.deepcopy(scm_message)
+        msg['headers'] = {'foo': 'bar', 'baz': 1, 'wibble': ['zork', 'zap']}
+        datanommer.models.add(msg)
+        dbmsg = datanommer.models.Message.query.first()
+        self.assertEquals(dbmsg.headers, msg['headers'])


### PR DESCRIPTION
Message headers can have relevant information, so let's store them in the database too.

Since we now have the headers, use the message-id header (if present) as the msg_id, in the case that the message body doesn't include a msg_id.