### PR TITLE
Avoid unique constraint violations

### DIFF
--- a/datanommer.consumer/tests/test_consumer.py
+++ b/datanommer.consumer/tests/test_consumer.py
@@ -68,9 +68,9 @@ class TestConsumer(unittest.TestCase):
 
     def test_duplicate_msg_id(self):
         example_message = dict(
-            topic="topiclol",
+            topic="topic.lol.lol.lol",
             body=dict(
-                topic="topiclol",
+                topic="topic.lol.lol.lol",
                 i=1,
                 msg_id="1234",
                 timestamp=1234,
@@ -86,10 +86,9 @@ class TestConsumer(unittest.TestCase):
         eq_(datanommer.models.Message.query.count(), 1)
 
         with mock.patch("fedmsg.publish") as mocked_function:
-            with self.assertRaises(IntegrityError):
-                # The database layer should raise an exception on
-                # the unique constraint violation.
-                self.consumer.consume(msg2)
+            # datanommer.models.add() now ignores duplicate messages
+            # (messages with the same msg_id).
+            self.consumer.consume(msg2)
             eq_(datanommer.models.Message.query.count(), 1)
 
         mocked_function.assert_not_called()

--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -39,6 +39,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.hybrid import hybrid_property
 
 from sqlalchemy.sql import literal, select, exists
+from sqlalchemy.exc import IntegrityError
 
 import pkg_resources
 
@@ -130,16 +131,14 @@ def add(envelope):
     obj.msg = message['msg']
     obj.headers = headers
 
-    # Construct an INSERT ... SELECT ... which will do nothing if an
-    # entry with a matching msg_id already exists. This can happen in the
-    # event of message redelivery.
-    cols = [c for c in Message.__table__.c if c.name != 'id']
-    vals = [literal(getattr(obj, c.name)) for c in cols]
-    not_exists = ~exists(select([Message.__table__.c.i]).\
-                         where(Message.msg_id == msg_id))
-    insert = Message.__table__.insert().from_select(cols, select(vals).\
-                                                    where(not_exists))
-    session.execute(insert)
+    try:
+        session.add(obj)
+        session.flush()
+    except IntegrityError:
+        log.warn('Skipping message from %s with duplicate id: %s',
+                 message['topic'], msg_id)
+        session.rollback()
+        return
 
     usernames = fedmsg.meta.msg2usernames(message)
     packages = fedmsg.meta.msg2packages(message)

--- a/datanommer.models/tests/test_model.py
+++ b/datanommer.models/tests/test_model.py
@@ -425,3 +425,17 @@ class TestModels(unittest.TestCase):
         # if no exception was thrown, then we successfully ignored the
         # duplicate message
         eq_(datanommer.models.Message.query.count(), 1)
+
+    def test_User_get_or_create(self):
+        eq_(datanommer.models.User.query.count(), 0)
+        datanommer.models.User.get_or_create(u'foo')
+        eq_(datanommer.models.User.query.count(), 1)
+        datanommer.models.User.get_or_create(u'foo')
+        eq_(datanommer.models.User.query.count(), 1)
+
+    def test_Package_get_or_create(self):
+        eq_(datanommer.models.Package.query.count(), 0)
+        datanommer.models.Package.get_or_create(u'foo')
+        eq_(datanommer.models.Package.query.count(), 1)
+        datanommer.models.Package.get_or_create(u'foo')
+        eq_(datanommer.models.Package.query.count(), 1)

--- a/datanommer.models/tests/test_model.py
+++ b/datanommer.models/tests/test_model.py
@@ -416,3 +416,12 @@ class TestModels(unittest.TestCase):
         datanommer.models.add(msg)
         dbmsg = datanommer.models.Message.query.first()
         self.assertEquals(dbmsg.msg_id, 'abc123')
+
+    def test_add_duplicate(self):
+        # use the github message because it has a msg_id
+        msg = copy.deepcopy(github_message)
+        datanommer.models.add(msg)
+        datanommer.models.add(msg)
+        # if no exception was thrown, then we successfully ignored the
+        # duplicate message
+        eq_(datanommer.models.Message.query.count(), 1)

--- a/datanommer.models/tests/test_model.py
+++ b/datanommer.models/tests/test_model.py
@@ -189,48 +189,37 @@ class TestModels(unittest.TestCase):
         if USE_SQLITE:
             fname = "sqlite:///%s" % filename
         else:
-            response = requests.get('http://209.132.184.152/faitout/new',
+            response = requests.get('http://faitout.fedorainfracloud.org/new',
                                     headers=dict(accept='application/json'))
             details = response.json()
             fname = "postgres://{username}:{password}@{host}:{port}/{dbname}"\
                 .format(**details)
             cls.dbname = details['dbname']
 
-        config['datanommer.sqlalchemy.url'] = fname
+        config['datanommer.sqlalchemy.url'] = cls.fname = fname
         fedmsg.meta.make_processors(**config)
 
     @classmethod
     def tearDownClass(cls):
         if not USE_SQLITE:
-            requests.get("http://209.132.184.152/faitout/drop/{dbname}"\
-                        .format(dbname=cls.dbname))
+            requests.get('http://faitout.fedorainfracloud.org/drop/{dbname}'\
+                         .format(dbname=cls.dbname))
 
     def setUp(self):
-        if USE_SQLITE:
-            fname = "sqlite:///%s" % filename
-        else:
-            response = requests.get('http://209.132.184.152/faitout/new',
-                                    headers=dict(accept='application/json'))
-            details = response.json()
-            import pprint
-            pprint.pprint(details)
-            fname = "postgres://{username}:{password}@{host}:{port}/{dbname}"\
-                .format(**details)
-            self.dbname2 = details['dbname']
+        if not USE_SQLITE:
+            response = requests.get('http://faitout.fedorainfracloud.org/clean/{dbname}'.\
+                                    format(dbname=self.dbname))
         # We only have to do this so that we can do it over
         # and over again for each test.
         datanommer.models.session = scoped_session(datanommer.models.maker)
-        datanommer.models.init(fname, create=True)
+        datanommer.models.init(self.fname, create=True)
 
 
     def tearDown(self):
         if USE_SQLITE:
             engine = datanommer.models.session.get_bind()
             datanommer.models.DeclarativeBase.metadata.drop_all(engine)
-        else:
-            datanommer.models.session.close()
-            requests.get("http://209.132.184.152/faitout/drop/{dbname}"\
-                        .format(dbname=self.dbname2))
+        datanommer.models.session.close()
 
         # These contain objects bound to the old session, so we have to flush.
         datanommer.models._users_seen = set()


### PR DESCRIPTION
Change inserts for Message, User, and Package objects into INSERT ... SELECTs, which avoids race conditions between existence checking and insert, which can lead to unique constraint violations.

Also fix up the tests so it is possible to test against faitout again.
