### PR TITLE
Set inline=True when using INSERT ... FROM SELECT.

### DIFF
--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -286,7 +286,7 @@ class Singleton(object):
         # violations if multiple instances of datanommer are trying to insert the same
         # value at the same time.
         not_exists = ~exists(select([cls.__table__.c.name]).where(cls.name == name))
-        insert = cls.__table__.insert().\
+        insert = cls.__table__.insert(inline=True).\
                  from_select([cls.__table__.c.name],
                              select([literal(name)]).where(not_exists))
         session.execute(insert)


### PR DESCRIPTION
By default, sqlalchemy will try to retrieve the last inserted value
from an insert/update/delete. If doing an INSERT/SELECT, this can
results in either no values, or multiple values being inserted, and
this will break the retrieval. Setting inline=True disables the
retrieval.

See:

https://github.com/zzzeek/sqlalchemy/blob/rel_0_9/lib/sqlalchemy/sql/dml.py#L504

for a longer explanation. Note that this is only a problem in sqlalchemy
0.9. 1.0 and higher set inline=True automatically for all relevant
cases.