### PR TITLE
Use a subquery to query the messages table

### DIFF
--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -365,7 +365,7 @@ class Message(DeclarativeBase, BaseMessage):
         not_topics = not_topics or []
         contains = contains or []
 
-        query = Message.query
+        query = session.query(Message.id)
 
         # A little argument validation.  We could provide some defaults in
         # these mixed cases.. but instead we'll just leave it up to our caller.
@@ -437,11 +437,15 @@ class Message(DeclarativeBase, BaseMessage):
             pages = int(math.ceil(total / float(rows_per_page)))
             query = query.offset(rows_per_page * (page - 1)).limit(rows_per_page)
 
+        final_query = session.query(Message).filter(
+            Message.id.in_(query.subquery())
+        )
+
         if defer:
-            return total, page, query
+            return total, page, final_query
         else:
             # Execute!
-            messages = query.all()
+            messages = final_query.all()
             return total, pages, messages
 
 models = frozenset((


### PR DESCRIPTION
I have observed in a few places that using a subquery can be vastly
quicker than using a regular query when doing large search.

This is an attempt to apply this field-knowledge to datanommer.

Looking for some explanation for this I found the following:
``
It is quite clear from the execution plan that in case of IN, EXISTS and
JOIN SQL Server Engines is smart enough to figure out what is the best
optimal plan of Merge Join for the same query and execute the same.
However, in the case of use of Equal (=) Operator, SQL Server is forced
to use Nested Loop and test each result of the inner query and compare
to outer query, leading to cut the performance.
``
Source: https://blog.sqlauthority.com/2010/06/06/sql-server-subquery-or-join-various-options-sql-server-engine-knows-the-best/

So it looks interesting but definitively needs testing.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>