### PR TITLE
remove non ascii character, fixes #99

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,8 +78,8 @@ you might have to adjust the command a little).  You can also add this \
 command to your ``~/.bashrc`` file to have it run automatically for you.
 
 
-Cloning upstream the git repo¶
-------------------------------
+Cloning upstream the git repo
+-----------------------------
 The source code is on github. 
 
 Get fedmsg::


### PR DESCRIPTION
the non ascii character in the readme, causes setup.py to fail an install.