### PR TITLE
Fix missing unicode type in Python 3

### DIFF
--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -41,6 +41,11 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.sql import literal, select, exists
 from sqlalchemy.exc import IntegrityError
 
+# Fix missing unicode type in Python 3
+import sys
+if (sys.version_info >= (3,0)):
+    unicode = str
+
 import pkg_resources
 
 import math

--- a/datanommer.models/tests/test_model.py
+++ b/datanommer.models/tests/test_model.py
@@ -21,6 +21,11 @@ import sqlalchemy.exc
 import unittest
 import requests
 
+# Fix missing unicode type in Python 3
+import sys
+if (sys.version_info >= (3,0)):
+    unicode = str
+
 from sqlalchemy.orm import scoped_session
 
 from nose.tools import raises


### PR DESCRIPTION
There is a following error when the test is running under Python 3:

`NameError: name 'unicode' is not defined`

The `unicode` type is missing in Python 3 and is replaced by `str` type.