### PR TITLE
fix the alembic migration script

### DIFF
--- a/datanommer.models/alembic/versions/57be773be52b_index_category_and_topic.py
+++ b/datanommer.models/alembic/versions/57be773be52b_index_category_and_topic.py
@@ -22,8 +22,8 @@ def upgrade():
     """ Creates an index on messages.category, messages.topic and
     messages.username
     """
-    op.create_index('messages_topic_id', 'messages', 'topic')
-    op.create_index('messages_category_id', 'messages', 'category')
+    op.create_index('messages_topic_id', 'messages', ['topic'])
+    op.create_index('messages_category_id', 'messages', ['category'])
 
 
 def downgrade():


### PR DESCRIPTION
The third argument to create_index() must be a list.