### PR TITLE
Undefined name: from six.moves import input

### DIFF
--- a/tools/active-contrib.py
+++ b/tools/active-contrib.py
@@ -36,12 +36,12 @@ import datetime
 import getpass
 import pprint
 
-from six.moves import raw_input
+from six.moves import input
 
 
 def prompt_creds():
     print("I need to query FAS to get the list of packagers..")
-    username = raw_input("FAS username: ")
+    username = input("FAS username: ")
     password = getpass.getpass("FAS password: ")
     return dict(username=username, password=password)
 

--- a/tools/active-contrib.py
+++ b/tools/active-contrib.py
@@ -36,6 +36,8 @@ import datetime
 import getpass
 import pprint
 
+from six.moves import raw_input
+
 
 def prompt_creds():
     print("I need to query FAS to get the list of packagers..")


### PR DESCRIPTION
__raw_input()__ was removed in Python 3 in favor of a rewritten version of __input()__.

[flake8](http://flake8.pycqa.org) testing of https://github.com/fedora-infra/datanommer on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tools/active-contrib.py:42:16: F821 undefined name 'raw_input'
    username = raw_input("FAS username: ")
               ^
./tools/gource/datanommer2gitlog.py:85:16: F821 undefined name 'cmp'
        return cmp(a['timestamp'], b['timestamp'])
               ^
2     F821 undefined name 'raw_input'
2
```