### PR TITLE
Add support for running the tests via tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ README.pdf
 *.pid
 *.log
 *.swo
+.tox/

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = py{27,36,37}
+skipsdist = True
+
+[testenv]
+usedevelop = True
+setenv =
+    PYTHONPATH={toxinidir}
+commands =
+    ./.travis-dev-setup.sh
+    ./.travis-runtests.sh
+
+


### PR DESCRIPTION
The Fedora Infrastructure is trying to converge the way to run tests on tox
to make it easier to integrate with ci.centos.org.
This commit adds support for running the tests with tox for python 2.7, 3.6
(added compared to travis), 3.7.

Signed-off-by: Pierre-Yves Chibon <pingou@pingoured.fr>