### PR TITLE
Serialize the message body as text in the database

### DIFF
--- a/datanommer.models/tests/test_jsonencodeddict.py
+++ b/datanommer.models/tests/test_jsonencodeddict.py
@@ -1,0 +1,61 @@
+import pytest
+from sqlalchemy import Column, create_engine, Integer, MetaData, Table
+from sqlalchemy.sql import select
+
+from datanommer.models import JSONEncodedDict
+
+
+@pytest.fixture
+def connection():
+    engine = create_engine("sqlite:///:memory:")
+    with engine.connect() as connection:
+        yield connection
+
+
+@pytest.fixture
+def table(connection):
+    metadata = MetaData()
+    table = Table(
+        "test_table",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("data", JSONEncodedDict),
+    )
+    metadata.create_all(connection)
+    yield table
+    metadata.drop_all(connection)
+
+
+def test_jsonencodeddict(connection, table):
+    connection.execute(table.insert().values(data={"foo": "bar"}))
+    # Check that it's stored as a string
+    for row in connection.execute("SELECT data FROM test_table"):
+        assert row["data"] == '{"foo": "bar"}'
+    # Check that SQLAlchemy retrieves it as a dict
+    for row in connection.execute(select(table.c.data)):
+        assert row["data"] == {"foo": "bar"}
+
+
+def test_jsonencodeddict_null(connection, table):
+    # Make sure NULL values are supported
+    connection.execute(table.insert().values(data=None))
+    for row in connection.execute(select(table.c.data)):
+        assert row["data"] is None
+
+
+def test_jsonencodeddict_compare(connection, table):
+    # Make sure NULL values are supported
+    connection.execute(table.insert().values(data={"foo": "bar"}))
+    for row in connection.execute(
+        select(table.c.data).filter(table.c.data == {"foo": "bar"})
+    ):
+        assert row["data"] == {"foo": "bar"}
+
+
+def test_jsonencodeddict_compare_like(connection, table):
+    # Make sure NULL values are supported
+    connection.execute(table.insert().values(data={"foo": "bar"}))
+    for row in connection.execute(
+        select(table.c.data).filter(table.c.data.like("%foo%"))
+    ):
+        assert row["data"] == {"foo": "bar"}

--- a/datanommer.models/tests/test_model.py
+++ b/datanommer.models/tests/test_model.py
@@ -405,6 +405,17 @@ def test_grep_not_packages(datanommer_models):
     assert messages[0].msg == example_message.body
 
 
+def test_grep_contains(datanommer_models):
+    example_message = generate_message(topic="org.fedoraproject.prod.bodhi.newupdate")
+    add(example_message)
+    session.flush()
+    t, p, r = Message.grep(contains=["doing"])
+    assert t == 1
+    assert p == 1
+    assert len(r) == 1
+    assert r[0].msg == example_message.body
+
+
 def test_grep_rows_per_page_none(datanommer_models):
     for x in range(0, 200):
         example_message = generate_message()
@@ -506,3 +517,16 @@ def test___json__deprecated(datanommer_models, caplog, mocker):
         Message.query.first().__json__()
 
     mock_as_dict.assert_called_once()
+
+
+def test_singleton_create(datanommer_models):
+    Package.get_or_create("foobar")
+    assert [p.name for p in Package.query.all()] == ["foobar"]
+
+
+def test_singleton_get_existing(datanommer_models):
+    p1 = Package.get_or_create("foobar")
+    # Clear the in-memory cache
+    Package._cache.clear()
+    p2 = Package.get_or_create("foobar")
+    assert p1.id == p2.id


### PR DESCRIPTION
Don't use a JSONB column because they are [limited in size](https://www.postgresql.org/message-id/CAKFQuwZZ95W5JxQ_fgzdPONeCenUJ59-RB_zQtSQ8puKUJEJiQ%40mail.gmail.com) and there seem to be no easy way to increase it.

We do have huge messages on mass rebuilds, so we should expect to go over the size limit.
