### PR TITLE
Don't crash on messages with duplicate packages or users

### DIFF
--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -240,7 +240,7 @@ class Message(DeclarativeBase):
             return
         assoc_col_name = assoc_table.c[0].name
         insert_values = []
-        for name in values:
+        for name in set(values):
             attr_obj = rel_class.get_or_create(name)
             # This would normally be a simple "obj.[users|packages].append(name)" kind
             # of statement, but here we drop down out of sqlalchemy's ORM and into the

--- a/datanommer.models/news/PR437.bug
+++ b/datanommer.models/news/PR437.bug
@@ -1,0 +1,1 @@
+Don't crash on messages with duplicate packages or users

--- a/datanommer.models/tests/test_model.py
+++ b/datanommer.models/tests/test_model.py
@@ -444,6 +444,32 @@ def test_add_integrity_error(datanommer_models, mocker, caplog):
     assert Message.query.count() == 0
 
 
+def test_add_duplicate_package(datanommer_models, caplog):
+    # Define a special message schema and register it
+    class MessageWithPackages(fedora_message.Message):
+        @property
+        def packages(self):
+            return ["pkg", "pkg"]
+
+    fedora_message._schema_name_to_class["MessageWithPackages"] = MessageWithPackages
+    fedora_message._class_to_schema_name[MessageWithPackages] = "MessageWithPackages"
+    example_message = MessageWithPackages(
+        topic="org.fedoraproject.test.a.nice.message",
+        body={"encouragement": "You're doing great!"},
+        headers=None,
+    )
+    try:
+        add(example_message)
+    except IntegrityError as e:
+        assert False, e
+    # if no exception was thrown, then we successfully ignored the
+    # duplicate message
+    assert Message.query.count() == 1
+    dbmsg = Message.query.first()
+    assert len(dbmsg.packages) == 1
+    assert dbmsg.packages[0].name == "pkg"
+
+
 def test_as_fedora_message_dict(datanommer_models):
     example_message = generate_message()
     add(example_message)


### PR DESCRIPTION
This avoids an `IntegrityError` when a package list or a users list has duplicates.