### PR TITLE
Don't crash on messages whose schema raise exceptions

### DIFF
--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -124,6 +124,26 @@ def add(message):
     else:
         sent_at = datetime.datetime.utcnow()
 
+    # Workaround schemas misbehaving
+    try:
+        usernames = message.usernames
+    except Exception:
+        log.exception(
+            "Could not get the list of users from a message on %s with id %s",
+            message.topic,
+            message.id,
+        )
+        usernames = []
+    try:
+        packages = message.packages
+    except Exception:
+        log.exception(
+            "Could not get the list of packages from a message on %s with id %s",
+            message.topic,
+            message.id,
+        )
+        packages = []
+
     Message.create(
         i=0,
         msg_id=message.id,
@@ -131,8 +151,8 @@ def add(message):
         timestamp=sent_at,
         msg=message.body,
         headers=headers,
-        users=message.usernames,
-        packages=message.packages,
+        users=usernames,
+        packages=packages,
     )
 
     session.commit()

--- a/datanommer.models/news/PR483.feature
+++ b/datanommer.models/news/PR483.feature
@@ -1,0 +1,1 @@
+Don't crash on messages whose schema raise exceptions


### PR DESCRIPTION
When a schema crashes while reading the packages or users, we want to handle it without crashing.