### PR TITLE
Fix path for datanommer-create-db in playbook

### DIFF
--- a/devel/ansible/roles/datanommer/tasks/main.yml
+++ b/devel/ansible/roles/datanommer/tasks/main.yml
@@ -75,7 +75,7 @@
 - name: Create datanommer db
   shell: /srv/venv/bin/poetry run datanommer-create-db
   args:
-    chdir: /home/vagrant/datanommer/
+    chdir: /home/vagrant/datanommer/datanommer.commands
   become: yes
   become_user: vagrant
 


### PR DESCRIPTION
Vagrant was failing on playbook block Create datanommer db. There was incomplete path to datanommer-create-db.