### PR TITLE
Create materialized view for the list of messages

### DIFF
--- a/datanommer.commands/README.rst
+++ b/datanommer.commands/README.rst
@@ -8,6 +8,7 @@ This package contains the console commands for datanommer, including::
  - datanommer-create-db
  - datanommer-dump
  - datanommer-stats
+ - datanommer-refresh-view
 
 Datanommer is a storage consumer for the Fedora Infrastructure Message Bus
 (fedmsg).  It is comprised of a `fedmsg <http://fedmsg.com>`_ consumer that

--- a/datanommer.commands/datanommer/commands/__init__.py
+++ b/datanommer.commands/datanommer/commands/__init__.py
@@ -24,6 +24,7 @@ import click
 from sqlalchemy import func, select
 
 import datanommer.models as m
+from datanommer.models.view import refresh_recent_topics
 
 from .utils import config_option, get_config
 
@@ -304,3 +305,22 @@ def latest(config_path, topic, category, overall, timestamp, timesince, human):
         results.append(formatter(result.category, result))
 
     click.echo(f"[{','.join(results)}]")
+
+
+@click.command()
+@config_option
+def refresh_view(config_path):
+    """Refresh the materialized view `recent_topics`.
+
+    This command should be run periodically via cron job to keep
+    the materialized view `recent_topics` up to date.
+    """
+    config = get_config(config_path)
+    m.init(
+        config["datanommer_sqlalchemy_url"],
+        alembic_ini=config["alembic_ini"],
+    )
+
+    refresh_recent_topics(m.session)
+
+    click.echo("Recent topics materialized view refreshed successfully")

--- a/datanommer.commands/news/1434.feature
+++ b/datanommer.commands/news/1434.feature
@@ -1,0 +1,1 @@
+Add `datanommer-refresh-view` command to refresh the `recent_topics` materialized view, intended to be run periodically via cron job to keep topic view up to date

--- a/datanommer.commands/pyproject.toml
+++ b/datanommer.commands/pyproject.toml
@@ -43,6 +43,7 @@ datanommer-dump = "datanommer.commands:dump"
 datanommer-stats = "datanommer.commands:stats"
 datanommer-latest = "datanommer.commands:latest"
 datanommer-extract-users = "datanommer.commands.extract_users:main"
+datanommer-refresh-view = "datanommer.commands:refresh_view"
 
 
 [build-system]

--- a/datanommer.commands/tests/test_commands.py
+++ b/datanommer.commands/tests/test_commands.py
@@ -517,3 +517,15 @@ def test_latest(datanommer_models, mock_config, mock_init):
     assert json_object[1]["git"]["body"] == {"Message 3": "Message 3"}
     assert json_object[0]["fas"]["body"] == {"Message 2": "Message 2"}
     assert len(json_object) == 2
+
+
+def test_refresh_view(datanommer_models, mock_config, mocker):
+    """Test the refresh_view command."""
+
+    mock_refresh = mocker.patch("datanommer.commands.refresh_recent_topics")
+
+    runner = CliRunner()
+    result = runner.invoke(datanommer.commands.refresh_view, [])
+
+    assert result.exit_code == 0, result.output
+    mock_refresh.assert_called_once_with(m.session)

--- a/datanommer.models/alembic.ini
+++ b/datanommer.models/alembic.ini
@@ -11,7 +11,7 @@ script_location = datanommer.models:alembic
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
 
-sqlalchemy.url = postgresql://datanommer:datanommer@localhost/datanommer
+sqlalchemy.url = postgresql://datanommer:datanommer@localhost/messages
 
 # Logging configuration
 [loggers]

--- a/datanommer.models/datanommer/models/__init__.py
+++ b/datanommer.models/datanommer/models/__init__.py
@@ -56,6 +56,8 @@ from sqlalchemy.orm import (
 )
 from sqlalchemy.sql import operators
 
+from .view import create_view
+
 
 try:
     from psycopg2.errors import UniqueViolation
@@ -104,6 +106,8 @@ def init(uri=None, alembic_ini=None, engine=None, create=False):
         with engine.begin() as connection:
             connection.execute(text("CREATE EXTENSION IF NOT EXISTS timescaledb"))
         DeclarativeBase.metadata.create_all(engine)
+        with engine.begin() as connection:
+            create_view(connection)
         # Loads the alembic configuration and generates the version table, with
         # the most recent revision stamped as head
         if alembic_ini is not None:  # pragma: no cover

--- a/datanommer.models/datanommer/models/alembic/versions/f4fdb5442d05_add_view_recent_topics.py
+++ b/datanommer.models/datanommer/models/alembic/versions/f4fdb5442d05_add_view_recent_topics.py
@@ -1,0 +1,36 @@
+"""Add view recent_topics
+
+Revision ID: f4fdb5442d05
+Revises: 429e6f2cba6f
+Create Date: 2025-05-30 13:52:11.648140
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "f4fdb5442d05"
+down_revision = "429e6f2cba6f"
+
+from alembic import op  # noqa: E402
+
+from datanommer.models.view import CreateMaterializedView, get_selectable  # noqa: E402
+
+
+def upgrade():
+
+    # Create the materialized view using the factored selectable
+    selectable = get_selectable()
+    op.execute(CreateMaterializedView("recent_topics", selectable))
+
+    # Create unique index on topic
+    op.create_index(
+        "uq_recent_topics_topic", "recent_topics", ["topic"], unique=True, if_not_exists=True
+    )
+
+    # Create index on message_count for sorting
+    op.create_index(
+        "ix_recent_topics_message_count", "recent_topics", ["message_count"], if_not_exists=True
+    )
+
+
+def downgrade():
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS recent_topics")

--- a/datanommer.models/datanommer/models/view.py
+++ b/datanommer.models/datanommer/models/view.py
@@ -1,0 +1,65 @@
+from sqlalchemy import DDL, func, select, text
+from sqlalchemy.ext import compiler
+from sqlalchemy.schema import DDLElement
+
+
+TIME_INTERVAL = "1 year"
+
+
+class CreateMaterializedView(DDLElement):
+    def __init__(self, name, selectable):
+        self.name = name
+        self.selectable = selectable
+
+
+@compiler.compiles(CreateMaterializedView)
+def _create_view(element, compiler, **kw):
+    selectable = compiler.sql_compiler.process(element.selectable, literal_binds=True)
+    return f"CREATE MATERIALIZED VIEW IF NOT EXISTS {element.name} AS {selectable}"
+
+
+def get_selectable():
+    """Factory function to create the selectable query for materialized view."""
+    from . import Message
+
+    return (
+        select(
+            Message.topic,
+            func.count().label("message_count"),
+            func.min(Message.timestamp).label("earliest"),
+            func.max(Message.timestamp).label("latest"),
+        )
+        .where(Message.timestamp >= text(f"NOW() - INTERVAL '{TIME_INTERVAL}'"))
+        .group_by(Message.topic)
+    )
+
+
+def refresh_recent_topics(connection):
+    """Standalone refresh function that can be called from cron.
+
+    Args:
+        connection: SQLAlchemy connection object
+    """
+    connection.execute(text("REFRESH MATERIALIZED VIEW CONCURRENTLY recent_topics"))
+
+
+def create_view(connection):
+    """Create the recent_topics materialized view with proper indexes."""
+
+    selectable = get_selectable()
+
+    # Create the materialized view
+    connection.execute(CreateMaterializedView("recent_topics", selectable))
+
+    # Create unique index on topic
+    connection.execute(
+        DDL("CREATE UNIQUE INDEX IF NOT EXISTS uq_recent_topics_topic " "ON recent_topics (topic)"),
+    )
+
+    # Create index on message_count for sorting
+    connection.execute(
+        DDL(
+            "CREATE INDEX IF NOT EXISTS ix_recent_topics_message_count "
+            "ON recent_topics (message_count)"
+        )
+    )

--- a/datanommer.models/news/1434.feature
+++ b/datanommer.models/news/1434.feature
@@ -1,0 +1,1 @@
+Add materialized view `recent_topics` that provides efficient querying of recent message topics with aggregated message counts and sorting capabilities

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -69,6 +69,7 @@ to interact with the datanommer database::
     $ datanommer-latest
     $ datanommer-stats
     $ datanommer-create-db
+    $ datanommer-refresh-view
 
 
 Guidelines

--- a/docs/sysadmin.rst
+++ b/docs/sysadmin.rst
@@ -37,3 +37,16 @@ You should see::
     INFO  [alembic.migration] Will assume transactional DDL.
     INFO  [alembic.migration] Running upgrade None -> 198447250956
     INFO  [alembic.migration] Running upgrade 198447250956 -> ae2801c4cd9
+
+Refreshing materialized view
+----------------------------
+
+The ``recent_topics`` materialized view needs to be refreshed periodically to keep the data current.
+
+To refresh manually::
+
+    (datanommer)$ datanommer-refresh-view
+
+To set up automatic refresh (say every 5 minutes) via cron job, add this to your crontab::
+
+    */5 * * * * datanommer-refresh-view


### PR DESCRIPTION
This PR adds below feature:
1. New materialized view `recent_topics` which groups on `messages.topic` and has count of messages for each `topic` for the last 1 year
2. Refresh functionality on the new view when a record is inserted in `messages` using event `after_insert` of `sqlalchemy`
3. Alembic migration for the same

The view gets created once the database objects (`messages`) are created and refreshes on every insert without blocking the table using the CONCURRENTLY functionality.
![Screenshot From 2025-05-30 15-13-41](https://github.com/user-attachments/assets/68e9e651-ec5c-408a-ad82-f54056793b10)

Thanks to check and let me know if you need any other information from my side or any changes you feel are to be made.

Also, I've changed the database name in `sqlalchemy.url` from `datanommer` to `messages` in `alembic.ini`. I've added details in [datagrepper](https://github.com/fedora-infra/datagrepper/issues/676#issuecomment-2918936762), thanks to check it  and let me know if my assumption is not correct.

Fixes: #1434 